### PR TITLE
Qiita が HTTPS に変えたのに追随

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -29,7 +29,7 @@
   },
   "author": "mzyy94",
   "content_scripts": [{
-    "matches": [ "http://qiita.com/*/items/*" ],
+    "matches": [ "https://qiita.com/*/items/*" ],
     "js": [ "vue.min.js", "index.js" ],
     "run_at": "document_start"
   }]


### PR DESCRIPTION
Qiita の投稿ページが HTTPS になり、よくないね出来なくなっていたのを修正しました。